### PR TITLE
Release 2.1

### DIFF
--- a/API.md
+++ b/API.md
@@ -411,8 +411,10 @@ The request variable is defined as:
  * Structure of request parameters
  * 
  * Contains request data
+ * http_protocol:             http protocol used (1.0 or 1.1)
  * http_verb:                 http method (GET, POST, PUT, DELETE, etc.), use '*' to match all http methods
  * http_url:                  url used to call this callback function or full url to call when used in a ulfius_send_http_request
+ * proxy:                     proxy address to use for outgoing connections, used by ulfius_send_http_request
  * check_server_certificate:  do not check server certificate and hostname if false (default true), used by ulfius_send_http_request
  * timeout                    connection timeout used by ulfius_send_http_request, default is 0
  * client_address:            IP address of the client
@@ -427,8 +429,10 @@ The request variable is defined as:
  * 
  */
 struct _u_request {
+  char *               http_protocol;
   char *               http_verb;
   char *               http_url;
+	char *               proxy;
   int                  check_server_certificate;
   long                 timeout;
   struct sockaddr *    client_address;
@@ -451,20 +455,21 @@ The response variable is defined as:
  * Structure of response parameters
  * 
  * Contains response data that must be set by the user
- * status:               HTTP status code (200, 404, 500, etc)
- * protocol:             HTTP Protocol sent
- * map_header:           map containing the header variables
- * nb_cookies:           number of cookies sent
- * map_cookie:           array of cookies sent
- * auth_realm:           realm to send to the client on authenticationb failed
- * binary_body:          a void * containing a raw binary content
- * binary_body_length:   the length of the binary_body
- * stream_callback:      callback function to stream data in response body
- * stream_callback_free: callback function to free data allocated for streaming
- * stream_size:          size of the streamed data (-1 if unknown)
- * stream_block_size:    size of each block to be streamed, set according to your system
- * stream_user_data:     user defined data that will be available in your callback stream functions
- * shared_data:          any data shared between callback functions, must be allocated and freed by the callback functions
+ * status:                              HTTP status code (200, 404, 500, etc)
+ * protocol:                            HTTP Protocol sent
+ * map_header:                          map containing the header variables
+ * nb_cookies:                          number of cookies sent
+ * map_cookie:                          array of cookies sent
+ * auth_realm:                          realm to send to the client on authenticationb failed
+ * binary_body:                         a void * containing a raw binary content
+ * binary_body_length:                  the length of the binary_body
+ * stream_callback:                     callback function to stream data in response body
+ * stream_callback_free:                callback function to free data allocated for streaming
+ * stream_size:                         size of the streamed data (-1 if unknown)
+ * stream_block_size:                   size of each block to be streamed, set according to your system
+ * stream_user_data:                    user defined data that will be available in your callback stream functions
+ * websocket_handle:                    handle for websocket extension
+ * shared_data:                         any data shared between callback functions, must be allocated and freed by the callback functions
  * 
  */
 struct _u_response {
@@ -481,6 +486,7 @@ struct _u_response {
   size_t             stream_size;
   unsigned int       stream_block_size;
   void             * stream_user_data;
+  void             * websocket_handle;
   void *             shared_data;
 };
 ```

--- a/API.md
+++ b/API.md
@@ -41,6 +41,18 @@ On your linker command, add ulfius as a dependency library, e.g. `-lulfius` for 
 
 ## API Documentation
 
+### Update existing programs from Ulfius 2.0 to 2.1
+
+- An annoying bug has been fixed that made streaming data a little buggy when used on raspbian. Now if you don't know the data size you're sending, use the macro U_STREAM_SIZE_UNKOWN instead of the previous value -1.  There is some updates in the stream callback function parameter types. Check the [streaming data documentation](#streaming-data).
+- The websocket data structures are no longer available directly in `struct _u_response` or `struct _u_instance`. But you shouldn't use them like this anyway so it won't be a problem.
+- Unify and update functions name `ulfius_set_*_body_response`. You may have to update your legacy code.
+The new functions names are:
+```c
+int ulfius_set_string_body_response(struct _u_response * response, const uint status, const char * body);
+int ulfius_set_binary_body_response(struct _u_response * response, const uint status, const char * body, const size_t length);
+int ulfius_set_empty_body_response(struct _u_response * response, const uint status);
+```
+
 ### Update existing programs from Ulfius 1.x to 2.0
 
 If you already have programs that use Ulfius 1.x and want to update them to the brand new fresh Ulfius 2.0, it may require the following minor changes.
@@ -465,7 +477,7 @@ The response variable is defined as:
  * binary_body_length:                  the length of the binary_body
  * stream_callback:                     callback function to stream data in response body
  * stream_callback_free:                callback function to free data allocated for streaming
- * stream_size:                         size of the streamed data (-1 if unknown)
+ * stream_size:                         size of the streamed data (U_STREAM_SIZE_UNKOWN if unknown)
  * stream_block_size:                   size of each block to be streamed, set according to your system
  * stream_user_data:                    user defined data that will be available in your callback stream functions
  * websocket_handle:                    handle for websocket extension
@@ -481,10 +493,10 @@ struct _u_response {
   char             * auth_realm;
   void             * binary_body;
   size_t             binary_body_length;
-  ssize_t         (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
+  int             (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
   void            (* stream_callback_free) (void * stream_user_data);
-  size_t             stream_size;
-  unsigned int       stream_block_size;
+  uint64_t           stream_size;
+  size_t             stream_block_size;
   void             * stream_user_data;
   void             * websocket_handle;
   void *             shared_data;
@@ -534,10 +546,10 @@ int ulfius_set_empty_body_response(struct _u_response * response, const uint sta
  */
 int ulfius_set_stream_response(struct _u_response * response, 
                                 const uint status,
-                                int (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
+                                int (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
                                 void (* stream_callback_free) (void * stream_user_data),
-                                size_t stream_size,
-                                unsigned int stream_block_size,
+                                uint64_t stream_size,
+                                size_t stream_block_size,
                                 void * stream_user_data);
 ```
 
@@ -727,14 +739,14 @@ See `examples/sheep_counter` for a file upload example.
 
 If you need to stream data, i.e. send a variable and potentially large amount of data, you can define and use `stream_callback_function` in the `struct _u_response`.
 
-Not that if you stream data to the client, any data that was in the `response->binary_body` will be ignored. You must at least set the function pointer `struct _u_response.stream_callback` to stream data. Set `stream_size` to -1 if you don't know the size of the data you need to send, like in audio stream for example. Set `stream_block_size` according to you system resources to avoid out of memory errors, also, set `stream_callback_free` with a pointer to a function that will free values allocated by your stream callback function, as a `close()` file for example, and finally, you can set `stream_user_data` to a pointer.
+Not that if you stream data to the client, any data that was in the `response->binary_body` will be ignored. You must at least set the function pointer `struct _u_response.stream_callback` to stream data. Set `stream_size` to U_STREAM_SIZE_UNKOWN if you don't know the size of the data you need to send, like in audio stream for example. Set `stream_block_size` according to you system resources to avoid out of memory errors, also, set `stream_callback_free` with a pointer to a function that will free values allocated by your stream callback function, as a `close()` file for example, and finally, you can set `stream_user_data` to a pointer.
 
 You can use the function `ulfius_set_stream_response` to set those parameters.
 
 The prototype of the `stream_callback` function is the following:
 
 ```C
-int stream_callback (void * stream_user_data, // Your predefined user_data
+int stream_callback (void * stream_user_data,  // Your predefined user_data
                      uint64_t offset,          // the position of the current data to send
                      char * out_buf,           // The output buffer to fill with data
                      size_t max);              // the max size of data to be put in the out_buf

--- a/API.md
+++ b/API.md
@@ -493,7 +493,7 @@ struct _u_response {
   char             * auth_realm;
   void             * binary_body;
   size_t             binary_body_length;
-  int             (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
+  ssize_t         (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
   void            (* stream_callback_free) (void * stream_user_data);
   uint64_t           stream_size;
   size_t             stream_block_size;
@@ -546,7 +546,7 @@ int ulfius_set_empty_body_response(struct _u_response * response, const uint sta
  */
 int ulfius_set_stream_response(struct _u_response * response, 
                                 const uint status,
-                                int (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
+                                ssize_t (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
                                 void (* stream_callback_free) (void * stream_user_data),
                                 uint64_t stream_size,
                                 size_t stream_block_size,
@@ -746,7 +746,7 @@ You can use the function `ulfius_set_stream_response` to set those parameters.
 The prototype of the `stream_callback` function is the following:
 
 ```C
-int stream_callback (void * stream_user_data,  // Your predefined user_data
+ssize_t stream_callback (void * stream_user_data,  // Your predefined user_data
                      uint64_t offset,          // the position of the current data to send
                      char * out_buf,           // The output buffer to fill with data
                      size_t max);              // the max size of data to be put in the out_buf

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ LIBULFIUS_LOCATION=./src
 LIBORCANIA_LOCATION=lib/orcania/src
 LIBYDER_LOCATION=lib/yder/src
 EXAMPLES_LOCATION=./example_programs
+TESTS_LOCATION=./test
 
 ifeq (($(JANSSONFLAG)),"")
 ADD_JANSSONFLAG="JANSSONFLAG=-DU_DISABLE_JANSSON"
@@ -40,6 +41,7 @@ clean:
 	cd $(LIBYDER_LOCATION) && $(MAKE) clean
 	cd $(LIBULFIUS_LOCATION) && $(MAKE) clean
 	cd $(EXAMPLES_LOCATION) && $(MAKE) clean
+	cd $(TESTS_LOCATION) && $(MAKE) clean
 
 install:
 	cd $(LIBULFIUS_LOCATION) && $(MAKE) install

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ Example callback functions are available in the folder [example_callbacks](https
 - [Hutch](https://github.com/babelouest/hutch), a safe locker for passwords and other secrets, using encryption on the client side only
 - [Taulas Raspberry Pi Serial interface](https://github.com/babelouest/taulas/tree/master/taulas_raspberrypi_serial), an interface for Arduino devices that implent [Taulas](https://github.com/babelouest/taulas/) protocol, a house automation protocol
 
+## What's new in Ulfius 2.1 ?
+
+I know it wasn't long since Ulfius 2.0 was released. But after some review and tests, I realized some adjustments had to be made to avoid bugs and to clean the framework a little bit more.
+
+Some of the adjustments made in the new release:
+- An annoying bug has been fixed that made streaming data a little buggy when used on raspbian. Now if you don't know the data size you're sending, use the macro U_STREAM_SIZE_UNKOWN instead of the previous value -1. There is some updates in the stream callback function parameter types. Check the [streaming data documentation](API.md#streaming-data).
+- Fix bug on `ulfius_send_http_request` that didn't send back all headers value with the same name (#19)
+- Fix websocket declaration structures to have them outside of the `ulfius.h`, because it could lead to horrifying bugs when you compile ulfius with websocket but add `#define U_DISABLE_WEBSOCKET` in your application.
+- Add proxy value for outgoing requests (#18)
+- Unify and update functions name `ulfius_set_[string|json|binary]_body`. You may have to update your legacy code.
+
+The minor version number has been incremented, from 2.0 to 2.1 because some of the changes may require changes in your own code.
+
 ## What's new in Ulfius 2.0 ?
 
 Ulfius 2.0 brings several changes that make the library incompatible with Ulfius 1.0.x branch. The goal of making Ulfius 2.0 is to make a spring cleaning of some functions, remove what is apparently useless, and should bring bugs and memory loss. The main new features are multiple callback functions and websockets implementation.

--- a/example_callbacks/static_file/static_file_callback.c
+++ b/example_callbacks/static_file/static_file_callback.c
@@ -93,11 +93,11 @@ int callback_static_file (const struct _u_request * request, struct _u_response 
         response->binary_body_length = length;
         u_map_put(response->map_header, "Content-Type", content_type);
       } else {
-        ulfius_set_string_response(response, 500, "Error processing static file");
+        ulfius_set_string_body_response(response, 500, "Error processing static file");
         y_log_message(Y_LOG_LEVEL_ERROR, "Static File Server - Internal error in %s", request->http_url);
       }
     } else {
-      ulfius_set_string_response(response, 404, "File not found");
+      ulfius_set_string_body_response(response, 404, "File not found");
     }
     o_free(file_path);
     o_free(file_requested);

--- a/example_programs/Makefile
+++ b/example_programs/Makefile
@@ -13,6 +13,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 #
 
+ULFIUS_LOCATION=../src
 SIMPLE_EXAMPLE_LOCATION=./simple_example
 SHEEP_COUNTER_LOCATION=./sheep_counter
 PROXY_EXAMPLE_LOCATION=./proxy_example
@@ -27,6 +28,7 @@ WEBSOCKET_EXAMPLE_LOCATION=./websocket_example
 all: debug
 
 debug:
+	cd $(ULFIUS_LOCATION) && $(MAKE) debug
 	cd $(SIMPLE_EXAMPLE_LOCATION) && $(MAKE) debug
 	cd $(SHEEP_COUNTER_LOCATION) && $(MAKE) debug
 	cd $(PROXY_EXAMPLE_LOCATION) && $(MAKE) debug

--- a/example_programs/auth_example/auth_server.c
+++ b/example_programs/auth_example/auth_server.c
@@ -36,7 +36,7 @@ int auth_basic (const struct _u_request * request, struct _u_response * response
       0 == o_strcmp(request->auth_basic_user, USER) && 0 == o_strcmp(request->auth_basic_password, PASSWORD)) {
     return U_CALLBACK_CONTINUE;
   } else {
-    ulfius_set_string_response(response, 401, "Error authentication");
+    ulfius_set_string_body_response(response, 401, "Error authentication");
     return U_CALLBACK_UNAUTHORIZED;
   }
 }
@@ -45,7 +45,7 @@ int auth_basic (const struct _u_request * request, struct _u_response * response
  * Callback function for basic authentication
  */
 int callback_auth_basic (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, "Basic auth callback");
+  ulfius_set_string_body_response(response, 200, "Basic auth callback");
   return U_CALLBACK_CONTINUE;
 }
 

--- a/example_programs/injection_example/injection_example.c
+++ b/example_programs/injection_example/injection_example.c
@@ -89,7 +89,7 @@ int main (int argc, char **argv) {
  * Callback callback_first
  */
 int callback_first (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, "Hello World from callback_first!");
+  ulfius_set_string_body_response(response, 200, "Hello World from callback_first!");
   return U_CALLBACK_CONTINUE;
 }
 
@@ -97,7 +97,7 @@ int callback_first (const struct _u_request * request, struct _u_response * resp
  * Callback callback_second
  */
 int callback_second (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, "Hello World from callback_second!");
+  ulfius_set_string_body_response(response, 200, "Hello World from callback_second!");
   return U_CALLBACK_CONTINUE;
 }
 
@@ -105,7 +105,7 @@ int callback_second (const struct _u_request * request, struct _u_response * res
  * Callback callback_third
  */
 int callback_third (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, "Hello World from callback_third!");
+  ulfius_set_string_body_response(response, 200, "Hello World from callback_third!");
   return U_CALLBACK_CONTINUE;
 }
 
@@ -113,7 +113,7 @@ int callback_third (const struct _u_request * request, struct _u_response * resp
  * Callback callback_fourth
  */
 int callback_fourth (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, "Hello World from callback_fourth!");
+  ulfius_set_string_body_response(response, 200, "Hello World from callback_fourth!");
   return U_CALLBACK_CONTINUE;
 }
 
@@ -121,6 +121,6 @@ int callback_fourth (const struct _u_request * request, struct _u_response * res
  * Callback callback_fifth
  */
 int callback_fifth (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, "Hello World from callback_fifth!");
+  ulfius_set_string_body_response(response, 200, "Hello World from callback_fifth!");
   return U_CALLBACK_CONTINUE;
 }

--- a/example_programs/multiple_callbacks_example/multiple_callbacks_example.c
+++ b/example_programs/multiple_callbacks_example/multiple_callbacks_example.c
@@ -12,6 +12,7 @@
  */
 
 #include <string.h>
+#include <stdio.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -144,7 +145,7 @@ int main (int argc, char **argv) {
  * Callback function of level zero
  */
 int callback_multiple_level_zero (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, "Level zero");
+  ulfius_set_string_body_response(response, 200, "Level zero");
   response->shared_data = o_strdup("shared from level zero");
   return U_CALLBACK_CONTINUE;
 }
@@ -158,7 +159,7 @@ int callback_multiple_level_one (const struct _u_request * request, struct _u_re
   memcpy(old_body, response->binary_body, response->binary_body_length);
   old_body[response->binary_body_length] = '\0';
   new_body = msprintf("%s\n%s", old_body, "Level one");
-  ulfius_set_string_response(response, 200, new_body);
+  ulfius_set_string_body_response(response, 200, new_body);
   o_free(new_body);
   y_log_message(Y_LOG_LEVEL_DEBUG, "shared_data is %s", response->shared_data);
   return U_CALLBACK_CONTINUE;
@@ -173,7 +174,7 @@ int callback_multiple_level_one_complete (const struct _u_request * request, str
   memcpy(old_body, response->binary_body, response->binary_body_length);
   old_body[response->binary_body_length] = '\0';
   new_body = msprintf("%s\n%s", old_body, "Level one");
-  ulfius_set_string_response(response, 200, new_body);
+  ulfius_set_string_body_response(response, 200, new_body);
   o_free(new_body);
   y_log_message(Y_LOG_LEVEL_DEBUG, "shared_data is %s", response->shared_data);
   o_free(response->shared_data);
@@ -189,7 +190,7 @@ int callback_multiple_level_two (const struct _u_request * request, struct _u_re
   memcpy(old_body, response->binary_body, response->binary_body_length);
   old_body[response->binary_body_length] = '\0';
   new_body = msprintf("%s\n%s", old_body, "Level two");
-  ulfius_set_string_response(response, 200, new_body);
+  ulfius_set_string_body_response(response, 200, new_body);
   o_free(new_body);
   y_log_message(Y_LOG_LEVEL_DEBUG, "shared_data is %s", response->shared_data);
   return U_CALLBACK_CONTINUE;
@@ -204,7 +205,7 @@ int callback_multiple_level_three (const struct _u_request * request, struct _u_
   memcpy(old_body, response->binary_body, response->binary_body_length);
   old_body[response->binary_body_length] = '\0';
   new_body = msprintf("%s\n%s", old_body, "Level three");
-  ulfius_set_string_response(response, 200, new_body);
+  ulfius_set_string_body_response(response, 200, new_body);
   o_free(new_body);
   y_log_message(Y_LOG_LEVEL_DEBUG, "shared_data is %s", response->shared_data);
   return U_CALLBACK_CONTINUE;
@@ -231,7 +232,7 @@ int callback_multiple_level_auth_check (const struct _u_request * request, struc
     if (0 == o_strcmp("PUT", request->http_verb)) {
       response->auth_realm = o_strdup(SPECIFIC_REALM);
     }
-    ulfius_set_string_response(response, 401, "Error authentication");
+    ulfius_set_string_body_response(response, 401, "Error authentication");
     return U_CALLBACK_UNAUTHORIZED;
   }
 }
@@ -240,7 +241,7 @@ int callback_multiple_level_auth_check (const struct _u_request * request, struc
  * Send Hello World!
  */
 int callback_multiple_level_auth_data (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, "Hello World!");
+  ulfius_set_string_body_response(response, 200, "Hello World!");
   return U_CALLBACK_CONTINUE;
 }
 
@@ -248,6 +249,6 @@ int callback_multiple_level_auth_data (const struct _u_request * request, struct
  * Default callback function called if no endpoint has a match
  */
 int callback_default (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 404, "Page not found, do what you want");
+  ulfius_set_string_body_response(response, 404, "Page not found, do what you want");
   return U_CALLBACK_CONTINUE;
 }

--- a/example_programs/request_example/server.c
+++ b/example_programs/request_example/server.c
@@ -65,6 +65,8 @@ int callback (const struct _u_request * request, struct _u_response * response, 
                                   request->http_verb, request->http_url, url_params, cookies, headers, post_params, request_body, (char *)user_data);
   
   ulfius_add_cookie_to_response(response, "cook", "ie", NULL, 5000, NULL, NULL, 0, 0);
+  u_map_put(response->map_header, "multiple-key", "value 1");
+  u_map_put(response->map_header, "Multiple-Key", "value 2");
   o_free(url_params);
   o_free(headers);
   o_free(cookies);

--- a/example_programs/sheep_counter/sheep_counter.c
+++ b/example_programs/sheep_counter/sheep_counter.c
@@ -263,7 +263,7 @@ int callback_upload_file (const struct _u_request * request, struct _u_response 
 
   char * string_body = msprintf("Upload file\n\n  method is %s\n  url is %s\n\n  parameters from the url are \n%s\n\n  cookies are \n%s\n\n  headers are \n%s\n\n  post parameters are \n%s\n\n",
                                   request->http_verb, request->http_url, url_params, cookies, headers, post_params);
-  ulfius_set_string_response(response, 200, string_body);
+  ulfius_set_string_body_response(response, 200, string_body);
   o_free(url_params);
   o_free(headers);
   o_free(cookies);

--- a/example_programs/sheep_counter/sheep_counter.c
+++ b/example_programs/sheep_counter/sheep_counter.c
@@ -268,5 +268,6 @@ int callback_upload_file (const struct _u_request * request, struct _u_response 
   o_free(headers);
   o_free(cookies);
   o_free(post_params);
+  o_free(string_body);
   return U_CALLBACK_CONTINUE;
 }

--- a/example_programs/simple_example/README.md
+++ b/example_programs/simple_example/README.md
@@ -17,9 +17,9 @@ If you want this program to listen to a secure (https) connection, create a cert
 - `GET http://localhost:8537/test`: A "Hello World!" response (status 200)
 - `GET http://localhost:8537/test/empty`: An empty response (status 200)
 - `POST http://localhost:8537/test`: Will display all requests parameters (body, headers, cookies, etc.) given by the client
-- `GET http://localhost:8537/test/:foo`: Will display all requests parameters (body, headers, cookies, etc.) given by the client
-- `POST http://localhost:8537/test/:foo`: Will display all requests parameters (body, headers, cookies, etc.) given by the client
-- `PUT http://localhost:8537/test/:foo`: Will display all requests parameters (body, headers, cookies, etc.) given by the client
-- `DELETE http://localhost:8537/test/:foo`: Will display all requests parameters (body, headers, cookies, etc.) given by the client
+- `GET http://localhost:8537/test/param/:foo`: Will display all requests parameters (body, headers, cookies, etc.) given by the client
+- `POST http://localhost:8537/test/param/:foo`: Will display all requests parameters (body, headers, cookies, etc.) given by the client
+- `PUT http://localhost:8537/test/param/:foo`: Will display all requests parameters (body, headers, cookies, etc.) given by the client
+- `DELETE http://localhost:8537/test/param/:foo`: Will display all requests parameters (body, headers, cookies, etc.) given by the client
 - `GET http://localhost:8537/test/multiple/:multiple/:multiple/:not_multiple`: Will display all requests parameters (body, headers, cookies, etc.) given by the client, and multiple values in `map_url:multiple` key
 - `GET http://localhost:8537/testcookie/:lang/:extra` Will send a cookie to the client with `lang` and `extra` values in it

--- a/example_programs/simple_example/simple_example.c
+++ b/example_programs/simple_example/simple_example.c
@@ -162,7 +162,7 @@ int main (int argc, char **argv) {
  * Callback function that put a "Hello World!" string in the response
  */
 int callback_get_test (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, "Hello World!");
+  ulfius_set_string_body_response(response, 200, "Hello World!");
   return U_CALLBACK_CONTINUE;
 }
 
@@ -179,7 +179,7 @@ int callback_get_empty_response (const struct _u_request * request, struct _u_re
 int callback_post_test (const struct _u_request * request, struct _u_response * response, void * user_data) {
   char * post_params = print_map(request->map_post_body);
   char * response_body = msprintf("Hello World!\n%s", post_params);
-  ulfius_set_string_response(response, 200, response_body);
+  ulfius_set_string_body_response(response, 200, response_body);
   o_free(response_body);
   o_free(post_params);
   return U_CALLBACK_CONTINUE;
@@ -193,7 +193,7 @@ int callback_all_test_foo (const struct _u_request * request, struct _u_response
         * post_params = print_map(request->map_post_body);
   char * response_body = msprintf("Hello World!\n\n  method is %s\n  url is %s\n\n  parameters from the url are \n%s\n\n  cookies are \n%s\n\n  headers are \n%s\n\n  post parameters are \n%s\n\n  user data is %s\n\nclient address is %s\n\n",
                                   request->http_verb, request->http_url, url_params, cookies, headers, post_params, (char *)user_data, inet_ntoa(((struct sockaddr_in *)request->client_address)->sin_addr));
-  ulfius_set_string_response(response, 200, response_body);
+  ulfius_set_string_body_response(response, 200, response_body);
   o_free(url_params);
   o_free(headers);
   o_free(cookies);
@@ -222,7 +222,7 @@ int callback_get_cookietest (const struct _u_request * request, struct _u_respon
   ulfius_add_cookie_to_response(response, "lang", lang, NULL, 0, NULL, NULL, 0, 0);
   ulfius_add_cookie_to_response(response, "extra", extra, NULL, 0, NULL, NULL, 0, 0);
   ulfius_add_cookie_to_response(response, "counter", new_counter, NULL, 0, NULL, NULL, 0, 0);
-  ulfius_set_string_response(response, 200, "Cookies set!");
+  ulfius_set_string_body_response(response, 200, "Cookies set!");
   
   return U_CALLBACK_CONTINUE;
 }
@@ -231,6 +231,6 @@ int callback_get_cookietest (const struct _u_request * request, struct _u_respon
  * Default callback function called if no endpoint has a match
  */
 int callback_default (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 404, "Page not found, do what you want");
+  ulfius_set_string_body_response(response, 404, "Page not found, do what you want");
   return U_CALLBACK_CONTINUE;
 }

--- a/example_programs/simple_example/simple_example.c
+++ b/example_programs/simple_example/simple_example.c
@@ -119,10 +119,10 @@ int main (int argc, char **argv) {
   ulfius_add_endpoint_by_val(&instance, "GET", PREFIX, "/empty", 0, &callback_get_empty_response, NULL);
   ulfius_add_endpoint_by_val(&instance, "GET", PREFIX, "/multiple/:multiple/:multiple/:not_multiple", 0, &callback_all_test_foo, NULL);
   ulfius_add_endpoint_by_val(&instance, "POST", PREFIX, NULL, 0, &callback_post_test, NULL);
-  ulfius_add_endpoint_by_val(&instance, "GET", PREFIX, "/:foo", 0, &callback_all_test_foo, "user data 1");
-  ulfius_add_endpoint_by_val(&instance, "POST", PREFIX, "/:foo", 0, &callback_all_test_foo, "user data 2");
-  ulfius_add_endpoint_by_val(&instance, "PUT", PREFIX, "/:foo", 0, &callback_all_test_foo, "user data 3");
-  ulfius_add_endpoint_by_val(&instance, "DELETE", PREFIX, "/:foo", 0, &callback_all_test_foo, "user data 4");
+  ulfius_add_endpoint_by_val(&instance, "GET", PREFIX, "/param/:foo", 0, &callback_all_test_foo, "user data 1");
+  ulfius_add_endpoint_by_val(&instance, "POST", PREFIX, "/param/:foo", 0, &callback_all_test_foo, "user data 2");
+  ulfius_add_endpoint_by_val(&instance, "PUT", PREFIX, "/param/:foo", 0, &callback_all_test_foo, "user data 3");
+  ulfius_add_endpoint_by_val(&instance, "DELETE", PREFIX, "/param/:foo", 0, &callback_all_test_foo, "user data 4");
   ulfius_add_endpoint_by_val(&instance, "GET", PREFIXCOOKIE, "/:lang/:extra", 0, &callback_get_cookietest, NULL);
   
   // default_endpoint declaration

--- a/example_programs/stream_example/Makefile
+++ b/example_programs/stream_example/Makefile
@@ -15,7 +15,7 @@
 CC=gcc
 CFLAGS=-c -Wall -D_REENTRANT $(ADDITIONALFLAGS)
 ULFIUS_LOCATION=../../src
-LIBS=-lc -lorcania -lulfius -L$(ULFIUS_LOCATION)
+LIBS=-lc -lorcania -lulfius -lyder -L$(ULFIUS_LOCATION)
 
 all: stream_example stream_client
 

--- a/example_programs/stream_example/stream_client.c
+++ b/example_programs/stream_example/stream_client.c
@@ -13,6 +13,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <yder.h>
+
 #define U_DISABLE_JANSSON
 #define U_DISABLE_WEBSOCKET
 #include "../../src/ulfius.h"
@@ -35,46 +37,53 @@ int main(void) {
   struct _u_request request;
   struct _u_response response;
   int res;
+	
+	y_init_logs("stream_example client", Y_LOG_MODE_CONSOLE, Y_LOG_LEVEL_DEBUG, NULL, "Starting stream_example");
   
   ulfius_init_response(&response);
   ulfius_init_request(&request);
   request.http_verb = o_strdup("GET");
   request.http_url = o_strdup(URL);
   
-  printf("Press <enter> to run stream test\n");
+  y_log_message(Y_LOG_LEVEL_DEBUG, "Press <enter> to run stream test");
   getchar();
   res = ulfius_send_http_streaming_request(&request, &response, my_write_body, NULL);
   if (res == U_OK) {
-    printf("ulfius_send_http_streaming_request OK\n");
+    y_log_message(Y_LOG_LEVEL_DEBUG, "ulfius_send_http_streaming_request OK");
   } else {
-    printf("Error in http request: %d\n", res);
+    y_log_message(Y_LOG_LEVEL_DEBUG, "Error in http request: %d", res);
   }
   ulfius_clean_response(&response);
   
-  printf("Press <enter> to run stream audio test\n");
+  y_log_message(Y_LOG_LEVEL_DEBUG, "Press <enter> to run stream audio test");
+  ulfius_init_response(&response);
   o_free(request.http_url);
   request.http_url = o_strdup(URL "/audio");
   getchar();
   res = ulfius_send_http_streaming_request(&request, &response, my_write_meta_body, NULL);
   if (res == U_OK) {
-    printf("ulfius_send_http_streaming_request OK\n");
+    y_log_message(Y_LOG_LEVEL_DEBUG, "ulfius_send_http_streaming_request OK");
   } else {
-    printf("Error in http request: %d\n", res);
+    y_log_message(Y_LOG_LEVEL_DEBUG, "Error in http request: %d", res);
   }
   ulfius_clean_response(&response);
   
-  printf("Press <enter> to run no stream test\n");
+  y_log_message(Y_LOG_LEVEL_DEBUG, "Press <enter> to run no stream test");
+  ulfius_init_response(&response);
   o_free(request.http_url);
   request.http_url = o_strdup("http://www.w3.org/");
   getchar();
   res = ulfius_send_http_request(&request, &response);
   if (res == U_OK) {
-    printf("ulfius_send_http_request OK\n");
+    y_log_message(Y_LOG_LEVEL_DEBUG, "ulfius_send_http_request OK");
   } else {
-    printf("Error in http request: %d\n", res);
+    y_log_message(Y_LOG_LEVEL_DEBUG, "Error in http request: %d", res);
   }
   ulfius_clean_response(&response);
   
   ulfius_clean_request(&request);
+	
+	y_close_logs();
+	
   return 0;
 }

--- a/example_programs/stream_example/stream_example.c
+++ b/example_programs/stream_example/stream_example.c
@@ -111,7 +111,7 @@ int callback_get_audio_stream (const struct _u_request * request, struct _u_resp
   }
 }
 
-int stream_data (void * cls, uint64_t pos, char * buf, size_t max) {
+ssize_t stream_data (void * cls, uint64_t pos, char * buf, size_t max) {
   printf("stream data %" PRIu64 " %zu\n", pos, max);
   sleep(1);
   if (pos <= 100) {
@@ -122,7 +122,7 @@ int stream_data (void * cls, uint64_t pos, char * buf, size_t max) {
   }
 }
 
-int stream_audio_file (void * cls, uint64_t pos, char * buf, size_t max) {
+ssize_t stream_audio_file (void * cls, uint64_t pos, char * buf, size_t max) {
   FILE *file = cls;
 
   (void) fseek (file, pos, SEEK_SET);

--- a/example_programs/stream_example/stream_example.c
+++ b/example_programs/stream_example/stream_example.c
@@ -80,7 +80,7 @@ int main (int argc, char **argv) {
  * Callback function
  */
 int callback_get_stream (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_stream_response(response, 200, stream_data, free_stream_data, -1, 32 * 1024, o_strdup("stream test"));
+  ulfius_set_stream_response(response, 200, stream_data, free_stream_data, U_STREAM_SIZE_UNKOWN, 32 * 1024, o_strdup("stream test"));
   return U_CALLBACK_CONTINUE;
 }
 
@@ -111,7 +111,7 @@ int callback_get_audio_stream (const struct _u_request * request, struct _u_resp
   }
 }
 
-ssize_t stream_data (void * cls, uint64_t pos, char * buf, size_t max) {
+int stream_data (void * cls, uint64_t pos, char * buf, size_t max) {
   printf("stream data %" PRIu64 " %zu\n", pos, max);
   sleep(1);
   if (pos <= 100) {
@@ -122,7 +122,7 @@ ssize_t stream_data (void * cls, uint64_t pos, char * buf, size_t max) {
   }
 }
 
-ssize_t stream_audio_file (void * cls, uint64_t pos, char * buf, size_t max) {
+int stream_audio_file (void * cls, uint64_t pos, char * buf, size_t max) {
   FILE *file = cls;
 
   (void) fseek (file, pos, SEEK_SET);

--- a/src/u_map.c
+++ b/src/u_map.c
@@ -511,7 +511,7 @@ const char * u_map_get_case(const struct _u_map * u_map, const char * key) {
  * return -1 if no match found
  * search is case sensitive
  */
-size_t u_map_get_length(const struct _u_map * u_map, const const char * key) {
+ssize_t u_map_get_length(const struct _u_map * u_map, const const char * key) {
   int i;
   if (u_map != NULL && key != NULL) {
     for (i=0; u_map->keys[i] != NULL; i++) {
@@ -530,7 +530,7 @@ size_t u_map_get_length(const struct _u_map * u_map, const const char * key) {
  * return -1 if no match found
  * search is case insensitive
  */
-size_t u_map_get_case_length(const struct _u_map * u_map, const const char * key) {
+ssize_t u_map_get_case_length(const struct _u_map * u_map, const const char * key) {
   int i;
   if (u_map != NULL && key != NULL) {
     for (i=0; u_map->keys[i] != NULL; i++) {

--- a/src/u_request.c
+++ b/src/u_request.c
@@ -261,6 +261,7 @@ int ulfius_init_request(struct _u_request * request) {
     request->http_protocol = NULL;
     request->http_verb = NULL;
     request->http_url = NULL;
+    request->proxy = NULL;
     request->timeout = 0L;
     request->check_server_certificate = 1;
     request->client_address = NULL;
@@ -284,6 +285,7 @@ int ulfius_clean_request(struct _u_request * request) {
     o_free(request->http_protocol);
     o_free(request->http_verb);
     o_free(request->http_url);
+    o_free(request->proxy);
     o_free(request->auth_basic_user);
     o_free(request->auth_basic_password);
     o_free(request->client_address);
@@ -295,6 +297,7 @@ int ulfius_clean_request(struct _u_request * request) {
     request->http_protocol = NULL;
     request->http_verb = NULL;
     request->http_url = NULL;
+    request->proxy = NULL;
     request->client_address = NULL;
     request->map_url = NULL;
     request->map_header = NULL;
@@ -337,8 +340,10 @@ struct _u_request * ulfius_duplicate_request(const struct _u_request * request) 
       new_request->http_protocol = o_strdup(request->http_protocol);
       new_request->http_verb = o_strdup(request->http_verb);
       new_request->http_url = o_strdup(request->http_url);
+      new_request->proxy = o_strdup(request->proxy);
       if ((new_request->http_verb == NULL && request->http_verb != NULL) ||
           (new_request->http_url == NULL && request->http_url != NULL) ||
+          (new_request->proxy == NULL && request->proxy != NULL) ||
           (new_request->http_protocol == NULL && request->http_protocol != NULL)) {
         y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Error allocating memory for ulfius_duplicate_request");
         ulfius_clean_request_full(new_request);

--- a/src/u_request.c
+++ b/src/u_request.c
@@ -395,7 +395,7 @@ struct _u_request * ulfius_duplicate_request(const struct _u_request * request) 
 
 #ifndef U_DISABLE_JANSSON
 /**
- * ulfius_set_json_response
+ * ulfius_set_json_body_request
  * Add a json_t binary_body to a response
  * return U_OK on success
  */

--- a/src/u_response.c
+++ b/src/u_response.c
@@ -540,20 +540,15 @@ int ulfius_copy_response(struct _u_response * dest, const struct _u_response * s
       memcpy(dest->binary_body, source->binary_body, source->binary_body_length);
     }
 #ifndef U_DISABLE_WEBSOCKET
-    if ((dest->websocket_handle = o_malloc(sizeof(struct _websocket_handle))) != NULL) {
-      if (source->websocket_handle != NULL) {
-        ((struct _websocket_handle *)dest->websocket_handle)->websocket_protocol = o_strdup(((struct _websocket_handle *)source->websocket_handle)->websocket_protocol);
-        ((struct _websocket_handle *)dest->websocket_handle)->websocket_extensions = o_strdup(((struct _websocket_handle *)source->websocket_handle)->websocket_extensions);
-        ((struct _websocket_handle *)dest->websocket_handle)->websocket_manager_callback = ((struct _websocket_handle *)source->websocket_handle)->websocket_manager_callback;
-        ((struct _websocket_handle *)dest->websocket_handle)->websocket_manager_user_data = ((struct _websocket_handle *)source->websocket_handle)->websocket_manager_user_data;
-        ((struct _websocket_handle *)dest->websocket_handle)->websocket_incoming_message_callback = ((struct _websocket_handle *)source->websocket_handle)->websocket_incoming_message_callback;
-        ((struct _websocket_handle *)dest->websocket_handle)->websocket_incoming_user_data = ((struct _websocket_handle *)source->websocket_handle)->websocket_incoming_user_data;
-        ((struct _websocket_handle *)dest->websocket_handle)->websocket_onclose_callback = ((struct _websocket_handle *)source->websocket_handle)->websocket_onclose_callback;
-        ((struct _websocket_handle *)dest->websocket_handle)->websocket_onclose_user_data = ((struct _websocket_handle *)source->websocket_handle)->websocket_onclose_user_data;
-      }
-    } else {
-      ulfius_clean_response(dest);
-      return U_ERROR_MEMORY;
+    if (source->websocket_handle != NULL) {
+      ((struct _websocket_handle *)dest->websocket_handle)->websocket_protocol = o_strdup(((struct _websocket_handle *)source->websocket_handle)->websocket_protocol);
+      ((struct _websocket_handle *)dest->websocket_handle)->websocket_extensions = o_strdup(((struct _websocket_handle *)source->websocket_handle)->websocket_extensions);
+      ((struct _websocket_handle *)dest->websocket_handle)->websocket_manager_callback = ((struct _websocket_handle *)source->websocket_handle)->websocket_manager_callback;
+      ((struct _websocket_handle *)dest->websocket_handle)->websocket_manager_user_data = ((struct _websocket_handle *)source->websocket_handle)->websocket_manager_user_data;
+      ((struct _websocket_handle *)dest->websocket_handle)->websocket_incoming_message_callback = ((struct _websocket_handle *)source->websocket_handle)->websocket_incoming_message_callback;
+      ((struct _websocket_handle *)dest->websocket_handle)->websocket_incoming_user_data = ((struct _websocket_handle *)source->websocket_handle)->websocket_incoming_user_data;
+      ((struct _websocket_handle *)dest->websocket_handle)->websocket_onclose_callback = ((struct _websocket_handle *)source->websocket_handle)->websocket_onclose_callback;
+      ((struct _websocket_handle *)dest->websocket_handle)->websocket_onclose_user_data = ((struct _websocket_handle *)source->websocket_handle)->websocket_onclose_user_data;
     }
 #endif
     return U_OK;

--- a/src/u_response.c
+++ b/src/u_response.c
@@ -642,10 +642,10 @@ int ulfius_set_empty_body_response(struct _u_response * response, const uint sta
  */
 int ulfius_set_stream_response(struct _u_response * response, 
                                 const uint status,
-                                ssize_t (* stream_callback) (void *stream_user_data, uint64_t offset, char * out_buf, size_t max),
-                                void (* stream_callback_free) (void *stream_user_data),
-                                size_t stream_size,
-                                unsigned int stream_block_size,
+                                ssize_t (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
+                                void (* stream_callback_free) (void * stream_user_data),
+                                uint64_t stream_size,
+                                size_t stream_block_size,
                                 void * stream_user_data) {
   if (response != NULL && stream_callback != NULL) {
     // Free all the bodies available

--- a/src/u_response.c
+++ b/src/u_response.c
@@ -642,7 +642,7 @@ int ulfius_set_empty_body_response(struct _u_response * response, const uint sta
  */
 int ulfius_set_stream_response(struct _u_response * response, 
                                 const uint status,
-                                int (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
+                                ssize_t (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
                                 void (* stream_callback_free) (void * stream_user_data),
                                 uint64_t stream_size,
                                 size_t stream_block_size,

--- a/src/u_response.c
+++ b/src/u_response.c
@@ -642,7 +642,7 @@ int ulfius_set_empty_body_response(struct _u_response * response, const uint sta
  */
 int ulfius_set_stream_response(struct _u_response * response, 
                                 const uint status,
-                                ssize_t (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
+                                int (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
                                 void (* stream_callback_free) (void * stream_user_data),
                                 uint64_t stream_size,
                                 size_t stream_block_size,

--- a/src/u_send_request.c
+++ b/src/u_send_request.c
@@ -194,6 +194,16 @@ int ulfius_send_http_streaming_request(const struct _u_request * request, struct
           return U_ERROR_LIBCURL;
         }
       }
+			
+			// Set proxy if defined
+			if (copy_request->proxy != NULL) {
+				if (curl_easy_setopt(curl_handle, CURLOPT_PROXY, copy_request->proxy) != CURLE_OK) {
+          y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Error setting proxy option");
+          ulfius_clean_request_full(copy_request);
+          curl_easy_cleanup(curl_handle);
+          return U_ERROR_LIBCURL;
+				}
+			}
       
       has_params = (o_strchr(copy_request->http_url, '?') != NULL);
       if (copy_request->map_url != NULL && u_map_count(copy_request->map_url) > 0) {

--- a/src/u_websocket.c
+++ b/src/u_websocket.c
@@ -64,29 +64,29 @@ int ulfius_set_websocket_response(struct _u_response * response,
                                                                        void * websocket_onclose_user_data),
                                    void * websocket_onclose_user_data) {
   if (response != NULL && (websocket_manager_callback != NULL || websocket_incoming_message_callback)) {
-    if (response->websocket_protocol != NULL) {
-      o_free(response->websocket_protocol);
+    if (((struct _websocket_handle *)response->websocket_handle)->websocket_protocol != NULL) {
+      o_free(((struct _websocket_handle *)response->websocket_handle)->websocket_protocol);
     }
-    response->websocket_protocol = o_strdup(websocket_protocol);
-    if (response->websocket_protocol == NULL && websocket_protocol != NULL) {
+    ((struct _websocket_handle *)response->websocket_handle)->websocket_protocol = o_strdup(websocket_protocol);
+    if (((struct _websocket_handle *)response->websocket_handle)->websocket_protocol == NULL && websocket_protocol != NULL) {
       y_log_message(Y_LOG_LEVEL_ERROR, "Error allocating resources for response->websocket_protocol");
       return U_ERROR_MEMORY;
     }
-    if (response->websocket_extensions != NULL) {
-      o_free(response->websocket_extensions);
+    if (((struct _websocket_handle *)response->websocket_handle)->websocket_extensions != NULL) {
+      o_free(((struct _websocket_handle *)response->websocket_handle)->websocket_extensions);
     }
-    response->websocket_extensions = o_strdup(websocket_extensions);
-    if (response->websocket_extensions == NULL && websocket_extensions != NULL) {
+    ((struct _websocket_handle *)response->websocket_handle)->websocket_extensions = o_strdup(websocket_extensions);
+    if (((struct _websocket_handle *)response->websocket_handle)->websocket_extensions == NULL && websocket_extensions != NULL) {
       y_log_message(Y_LOG_LEVEL_ERROR, "Error allocating resources for response->websocket_extensions");
-      o_free(response->websocket_protocol);
+      o_free(((struct _websocket_handle *)response->websocket_handle)->websocket_protocol);
       return U_ERROR_MEMORY;
     }
-    response->websocket_manager_callback = websocket_manager_callback;
-    response->websocket_manager_user_data = websocket_manager_user_data;
-    response->websocket_incoming_message_callback = websocket_incoming_message_callback;
-    response->websocket_incoming_user_data = websocket_incoming_user_data;
-    response->websocket_onclose_callback = websocket_onclose_callback;
-    response->websocket_onclose_user_data = websocket_onclose_user_data;
+    ((struct _websocket_handle *)response->websocket_handle)->websocket_manager_callback = websocket_manager_callback;
+    ((struct _websocket_handle *)response->websocket_handle)->websocket_manager_user_data = websocket_manager_user_data;
+    ((struct _websocket_handle *)response->websocket_handle)->websocket_incoming_message_callback = websocket_incoming_message_callback;
+    ((struct _websocket_handle *)response->websocket_handle)->websocket_incoming_user_data = websocket_incoming_user_data;
+    ((struct _websocket_handle *)response->websocket_handle)->websocket_onclose_callback = websocket_onclose_callback;
+    ((struct _websocket_handle *)response->websocket_handle)->websocket_onclose_user_data = websocket_onclose_user_data;
     return U_OK;
   } else {
     return U_ERROR_PARAMS;
@@ -692,13 +692,13 @@ void ulfius_clear_websocket_manager(struct _websocket_manager * websocket_manage
  */
 int ulfius_instance_add_websocket_active(struct _u_instance * instance, struct _websocket * websocket) {
   if (instance != NULL && websocket != NULL) {
-    instance->websocket_active = o_realloc(instance->websocket_active, (instance->nb_websocket_active+1)*sizeof(struct _websocket *));
-    if (instance->websocket_active != NULL) {
-      instance->websocket_active[instance->nb_websocket_active] = websocket;
-      instance->nb_websocket_active++;
+    ((struct _websocket_handler *)instance->websocket_handler)->websocket_active = o_realloc(((struct _websocket_handler *)instance->websocket_handler)->websocket_active, (((struct _websocket_handler *)instance->websocket_handler)->nb_websocket_active+1)*sizeof(struct _websocket *));
+    if (((struct _websocket_handler *)instance->websocket_handler)->websocket_active != NULL) {
+      ((struct _websocket_handler *)instance->websocket_handler)->websocket_active[((struct _websocket_handler *)instance->websocket_handler)->nb_websocket_active] = websocket;
+      ((struct _websocket_handler *)instance->websocket_handler)->nb_websocket_active++;
       return U_OK;
     } else {
-      y_log_message(Y_LOG_LEVEL_ERROR, "Error allocating resources for instance->websocket_active");
+      y_log_message(Y_LOG_LEVEL_ERROR, "Error allocating resources for instance->websocket_handler->websocket_active");
       return U_ERROR_MEMORY;
     }
   } else {
@@ -711,23 +711,23 @@ int ulfius_instance_add_websocket_active(struct _u_instance * instance, struct _
  */
 int ulfius_instance_remove_websocket_active(struct _u_instance * instance, struct _websocket * websocket) {
   size_t i, j;
-  if (instance != NULL && instance->websocket_active != NULL && websocket != NULL) {
-    for (i=0; i<instance->nb_websocket_active; i++) {
-      if (instance->websocket_active[i] == websocket) {
-        if (instance->nb_websocket_active > 1) {
-          for (j=i; j<instance->nb_websocket_active-1; j++) {
-            instance->websocket_active[j] = instance->websocket_active[j+1];
+  if (instance != NULL && ((struct _websocket_handler *)instance->websocket_handler)->websocket_active != NULL && websocket != NULL) {
+    for (i=0; i<((struct _websocket_handler *)instance->websocket_handler)->nb_websocket_active; i++) {
+      if (((struct _websocket_handler *)instance->websocket_handler)->websocket_active[i] == websocket) {
+        if (((struct _websocket_handler *)instance->websocket_handler)->nb_websocket_active > 1) {
+          for (j=i; j<((struct _websocket_handler *)instance->websocket_handler)->nb_websocket_active-1; j++) {
+            ((struct _websocket_handler *)instance->websocket_handler)->websocket_active[j] = ((struct _websocket_handler *)instance->websocket_handler)->websocket_active[j+1];
           }
-          instance->websocket_active = o_realloc(instance->websocket_active, (instance->nb_websocket_active-1)*sizeof(struct _websocket *));
-          if (instance->websocket_active == NULL) {
+          ((struct _websocket_handler *)instance->websocket_handler)->websocket_active = o_realloc(((struct _websocket_handler *)instance->websocket_handler)->websocket_active, (((struct _websocket_handler *)instance->websocket_handler)->nb_websocket_active-1)*sizeof(struct _websocket *));
+          if (((struct _websocket_handler *)instance->websocket_handler)->websocket_active == NULL) {
             y_log_message(Y_LOG_LEVEL_ERROR, "Error allocating resources for instance->websocket_active");
             return U_ERROR_MEMORY;
           }
         } else {
-          o_free(instance->websocket_active);
-          instance->websocket_active = NULL;
+          o_free(((struct _websocket_handler *)instance->websocket_handler)->websocket_active);
+          ((struct _websocket_handler *)instance->websocket_handler)->websocket_active = NULL;
         }
-        instance->nb_websocket_active--;
+        ((struct _websocket_handler *)instance->websocket_handler)->nb_websocket_active--;
         return U_OK;
       }
     }

--- a/src/ulfius.c
+++ b/src/ulfius.c
@@ -451,7 +451,7 @@ int ulfius_webservice_dispatcher (void * cls, struct MHD_Connection * connection
           if (response->stream_callback != NULL) {
             // Call the stream_callback function to build the response binary_body
             // A stram_callback is always the last one
-            mhd_response = MHD_create_response_from_callback(response->stream_size, response->stream_block_size, (MHD_ContentReaderCallback)response->stream_callback, response->stream_user_data, response->stream_callback_free);
+            mhd_response = MHD_create_response_from_callback(response->stream_size, response->stream_block_size, response->stream_callback, response->stream_user_data, response->stream_callback_free);
             if (mhd_response == NULL) {
               y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Error MHD_create_response_from_callback");
               mhd_ret = MHD_NO;

--- a/src/ulfius.c
+++ b/src/ulfius.c
@@ -139,8 +139,11 @@ struct MHD_Daemon * ulfius_run_mhd_daemon(struct _u_instance * u_instance, const
 #ifdef DEBUG
   mhd_flags |= MHD_USE_DEBUG;
 #endif
+#ifdef MHD_USE_INTERNAL_POLLING_THREAD
+  mhd_flags |= MHD_USE_INTERNAL_POLLING_THREAD;
+#endif
 #ifndef U_DISABLE_WEBSOCKET
-  mhd_flags |= MHD_ALLOW_UPGRADE | MHD_USE_INTERNAL_POLLING_THREAD;
+  mhd_flags |= MHD_ALLOW_UPGRADE;
 #endif
   
   if (u_instance->mhd_daemon == NULL) {

--- a/src/ulfius.c
+++ b/src/ulfius.c
@@ -451,7 +451,7 @@ int ulfius_webservice_dispatcher (void * cls, struct MHD_Connection * connection
           if (response->stream_callback != NULL) {
             // Call the stream_callback function to build the response binary_body
             // A stram_callback is always the last one
-            mhd_response = MHD_create_response_from_callback(response->stream_size, response->stream_block_size, response->stream_callback, response->stream_user_data, response->stream_callback_free);
+            mhd_response = MHD_create_response_from_callback(response->stream_size, response->stream_block_size, (MHD_ContentReaderCallback)response->stream_callback, response->stream_user_data, response->stream_callback_free);
             if (mhd_response == NULL) {
               y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Error MHD_create_response_from_callback");
               mhd_ret = MHD_NO;

--- a/src/ulfius.c
+++ b/src/ulfius.c
@@ -139,7 +139,7 @@ struct MHD_Daemon * ulfius_run_mhd_daemon(struct _u_instance * u_instance, const
 #ifdef DEBUG
   mhd_flags |= MHD_USE_DEBUG;
 #endif
-#ifdef MHD_USE_INTERNAL_POLLING_THREAD
+#if MHD_VERSION >= 0x00095300
   mhd_flags |= MHD_USE_INTERNAL_POLLING_THREAD;
 #endif
 #ifndef U_DISABLE_WEBSOCKET
@@ -451,7 +451,7 @@ int ulfius_webservice_dispatcher (void * cls, struct MHD_Connection * connection
           if (response->stream_callback != NULL) {
             // Call the stream_callback function to build the response binary_body
             // A stram_callback is always the last one
-            mhd_response = MHD_create_response_from_callback(response->stream_size, response->stream_block_size, (MHD_ContentReaderCallback)response->stream_callback, response->stream_user_data, response->stream_callback_free);
+            mhd_response = MHD_create_response_from_callback(response->stream_size, response->stream_block_size, response->stream_callback, response->stream_user_data, response->stream_callback_free);
             if (mhd_response == NULL) {
               y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Error MHD_create_response_from_callback");
               mhd_ret = MHD_NO;

--- a/src/ulfius.h
+++ b/src/ulfius.h
@@ -97,6 +97,7 @@ struct _u_cookie {
  * http_protocol:             http protocol used (1.0 or 1.1)
  * http_verb:                 http method (GET, POST, PUT, DELETE, etc.), use '*' to match all http methods
  * http_url:                  url used to call this callback function or full url to call when used in a ulfius_send_http_request
+ * proxy:                     proxy address to use for outgoing connections, used by ulfius_send_http_request
  * check_server_certificate:  do not check server certificate and hostname if false (default true), used by ulfius_send_http_request
  * timeout                    connection timeout used by ulfius_send_http_request, default is 0
  * client_address:            IP address of the client
@@ -114,6 +115,7 @@ struct _u_request {
   char *               http_protocol;
   char *               http_verb;
   char *               http_url;
+	char *               proxy;
   int                  check_server_certificate;
   long                 timeout;
   struct sockaddr *    client_address;

--- a/src/ulfius.h
+++ b/src/ulfius.h
@@ -161,7 +161,7 @@ struct _u_response {
   char             * auth_realm;
   void             * binary_body;
   size_t             binary_body_length;
-  int             (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
+  ssize_t         (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
   void            (* stream_callback_free) (void * stream_user_data);
   uint64_t           stream_size;
   size_t             stream_block_size;
@@ -519,7 +519,7 @@ int ulfius_set_empty_body_response(struct _u_response * response, const uint sta
  */
 int ulfius_set_stream_response(struct _u_response * response, 
                                 const uint status,
-                                int (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
+                                ssize_t (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
                                 void (* stream_callback_free) (void * stream_user_data),
                                 uint64_t stream_size,
                                 size_t stream_block_size,

--- a/src/ulfius.h
+++ b/src/ulfius.h
@@ -44,6 +44,7 @@
 #define ULFIUS_STREAM_BLOCK_SIZE_DEFAULT 1024
 #define U_STREAM_END MHD_CONTENT_READER_END_OF_STREAM
 #define U_STREAM_ERROR MHD_CONTENT_READER_END_WITH_ERROR
+#define U_STREAM_SIZE_UNKOWN MHD_SIZE_UNKNOWN
 
 #define U_OK                 0 // No error
 #define U_ERROR              1 // Error
@@ -144,7 +145,7 @@ struct _u_request {
  * binary_body_length:                  the length of the binary_body
  * stream_callback:                     callback function to stream data in response body
  * stream_callback_free:                callback function to free data allocated for streaming
- * stream_size:                         size of the streamed data (-1 if unknown)
+ * stream_size:                         size of the streamed data (U_STREAM_SIZE_UNKOWN if unknown)
  * stream_block_size:                   size of each block to be streamed, set according to your system
  * stream_user_data:                    user defined data that will be available in your callback stream functions
  * websocket_handle:                    handle for websocket extension
@@ -160,10 +161,10 @@ struct _u_response {
   char             * auth_realm;
   void             * binary_body;
   size_t             binary_body_length;
-  ssize_t         (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
+  int             (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max);
   void            (* stream_callback_free) (void * stream_user_data);
-  size_t             stream_size;
-  unsigned int       stream_block_size;
+  uint64_t           stream_size;
+  size_t             stream_block_size;
   void             * stream_user_data;
   void             * websocket_handle;
   void *             shared_data;
@@ -518,10 +519,10 @@ int ulfius_set_empty_body_response(struct _u_response * response, const uint sta
  */
 int ulfius_set_stream_response(struct _u_response * response, 
                                 const uint status,
-                                ssize_t (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
+                                int (* stream_callback) (void * stream_user_data, uint64_t offset, char * out_buf, size_t max),
                                 void (* stream_callback_free) (void * stream_user_data),
-                                size_t stream_size,
-                                unsigned int stream_block_size,
+                                uint64_t stream_size,
+                                size_t stream_block_size,
                                 void * stream_user_data);
 
 /**

--- a/src/ulfius.h
+++ b/src/ulfius.h
@@ -53,19 +53,12 @@
 #define U_ERROR_LIBCURL      5 // Error in libcurl execution
 #define U_ERROR_NOT_FOUND    6 // Something was not found
 
-#define ULFIUS_VERSION 2.0
+#define ULFIUS_VERSION 2.1
 
 #define U_CALLBACK_CONTINUE     0
 #define U_CALLBACK_COMPLETE     1
 #define U_CALLBACK_UNAUTHORIZED 2
 #define U_CALLBACK_ERROR        3
-
-#ifndef U_DISABLE_WEBSOCKET
-  struct _websocket;
-  struct _websocket_manager;
-  struct _websocket_message;
-  struct _websocket_message_list;
-#endif
 
 /*************
  * Structures
@@ -152,12 +145,7 @@ struct _u_request {
  * stream_size:                         size of the streamed data (-1 if unknown)
  * stream_block_size:                   size of each block to be streamed, set according to your system
  * stream_user_data:                    user defined data that will be available in your callback stream functions
- * websocket_manager_callback:          callback function for working with the websocket
- * websocket_manager_user_data:         user-defined data that will be handled to websocket_manager_callback
- * websocket_incoming_message_callback: callback function that will be called every time a message arrives from the client in the websocket
- * websocket_incoming_user_data:        user-defined data that will be handled to websocket_incoming_message_callback
- * websocket_onclose_callback:          callback function that will be called if the websocket is open while the program calls ulfius_stop_framework
- * websocket_onclose_user_data:         user-defined data that will be handled to websocket_onclose_callback
+ * websocket_handle:                    handle for websocket extension
  * shared_data:                         any data shared between callback functions, must be allocated and freed by the callback functions
  * 
  */
@@ -175,23 +163,7 @@ struct _u_response {
   size_t             stream_size;
   unsigned int       stream_block_size;
   void             * stream_user_data;
-#ifndef U_DISABLE_WEBSOCKET
-  char             * websocket_protocol;
-  char             * websocket_extensions;
-  void            (* websocket_manager_callback) (const struct _u_request * request,
-                                                  struct _websocket_manager * websocket_manager,
-                                                  void * websocket_manager_user_data);
-  void             * websocket_manager_user_data;
-  void            (* websocket_incoming_message_callback) (const struct _u_request * request,
-                                                           struct _websocket_manager * websocket_manager,
-                                                           const struct _websocket_message * message,
-                                                           void * websocket_incoming_user_data);
-  void             * websocket_incoming_user_data;
-  void            (* websocket_onclose_callback) (const struct _u_request * request,
-                                                  struct _websocket_manager * websocket_manager,
-                                                  void * websocket_onclose_user_data);
-  void             * websocket_onclose_user_data;
-#endif
+  void             * websocket_handle;
   void *             shared_data;
 };
 
@@ -255,10 +227,7 @@ struct _u_instance {
   struct _u_map               * default_headers;
   size_t                        max_post_param_size;
   size_t                        max_post_body_size;
-#ifndef U_DISABLE_WEBSOCKET
-  size_t                        nb_websocket_active;
-  struct _websocket          ** websocket_active;
-#endif 
+  void                        * websocket_handler;
 };
 
 /**
@@ -519,26 +488,26 @@ int ulfius_add_cookie_to_response(struct _u_response * response, const char * ke
 int ulfius_add_header_to_response(struct _u_response * response, const char * key, const char * value);
 
 /**
- * ulfius_set_string_response
+ * ulfius_set_string_body_response
  * Add a string body to a response
  * body must end with a '\0' character
  * return U_OK on success
  */
-int ulfius_set_string_response(struct _u_response * response, const uint status, const char * body);
+int ulfius_set_string_body_response(struct _u_response * response, const uint status, const char * body);
 
 /**
- * ulfius_set_binary_response
+ * ulfius_set_binary_body_response
  * Add a binary body to a response
  * return U_OK on success
  */
-int ulfius_set_binary_response(struct _u_response * response, const uint status, const char * body, const size_t length);
+int ulfius_set_binary_body_response(struct _u_response * response, const uint status, const char * body, const size_t length);
 
 /**
- * ulfius_set_empty_response
+ * ulfius_set_empty_body_response
  * Set an empty response with only a status
  * return U_OK on success
  */
-int ulfius_set_empty_response(struct _u_response * response, const uint status);
+int ulfius_set_empty_body_response(struct _u_response * response, const uint status);
 
 /**
  * ulfius_set_stream_response
@@ -639,21 +608,21 @@ struct _u_response * ulfius_duplicate_response(const struct _u_response * respon
 json_t * ulfius_get_json_body_request(const struct _u_request * request, json_error_t * json_error);
 
 /**
- * ulfius_set_json_response
+ * ulfius_set_json_body_request
  * Add a json_t body to a request
  * return U_OK on success
  */
 int ulfius_set_json_body_request(struct _u_request * request, json_t * body);
 
 /**
- * ulfius_set_json_response
+ * ulfius_set_json_body_response
  * Add a json_t body to a response
  * return U_OK on success
  */
 int ulfius_set_json_body_response(struct _u_response * response, const uint status, const json_t * body);
 
 /**
- * ulfius_get_json_response
+ * ulfius_get_json_body_response
  * Get JSON structure from the response body if the request is valid
  */
 json_t * ulfius_get_json_body_response(struct _u_response * response, json_error_t * json_error);
@@ -756,14 +725,14 @@ int u_map_put_binary(struct _u_map * u_map, const char * key, const char * value
  * return -1 if no match found
  * search is case sensitive
  */
-size_t u_map_get_length(const struct _u_map * u_map, const char * key);
+ssize_t u_map_get_length(const struct _u_map * u_map, const char * key);
 
 /**
  * get the value length corresponding to the specified key in the u_map
  * return -1 if no match found
  * search is case insensitive
  */
-size_t u_map_get_case_length(const struct _u_map * u_map, const char * key);
+ssize_t u_map_get_case_length(const struct _u_map * u_map, const char * key);
 
 /**
  * get the value corresponding to the specified key in the u_map
@@ -1109,6 +1078,37 @@ char * ulfius_get_cookie_header(const struct _u_cookie * cookie);
 #define U_STATUS_ERROR    2
 
 #ifndef U_DISABLE_WEBSOCKET
+
+/**
+ * websocket_manager_callback:          callback function for working with the websocket
+ * websocket_manager_user_data:         user-defined data that will be handled to websocket_manager_callback
+ * websocket_incoming_message_callback: callback function that will be called every time a message arrives from the client in the websocket
+ * websocket_incoming_user_data:        user-defined data that will be handled to websocket_incoming_message_callback
+ * websocket_onclose_callback:          callback function that will be called if the websocket is open while the program calls ulfius_stop_framework
+ * websocket_onclose_user_data:         user-defined data that will be handled to websocket_onclose_callback
+ */
+struct _websocket_handle {
+  char             * websocket_protocol;
+  char             * websocket_extensions;
+  void            (* websocket_manager_callback) (const struct _u_request * request,
+                                                  struct _websocket_manager * websocket_manager,
+                                                  void * websocket_manager_user_data);
+  void             * websocket_manager_user_data;
+  void            (* websocket_incoming_message_callback) (const struct _u_request * request,
+                                                           struct _websocket_manager * websocket_manager,
+                                                           const struct _websocket_message * message,
+                                                           void * websocket_incoming_user_data);
+  void             * websocket_incoming_user_data;
+  void            (* websocket_onclose_callback) (const struct _u_request * request,
+                                                  struct _websocket_manager * websocket_manager,
+                                                  void * websocket_onclose_user_data);
+  void             * websocket_onclose_user_data;
+};
+
+struct _websocket_handler {
+  size_t                        nb_websocket_active;
+  struct _websocket          ** websocket_active;
+};
 
 /**
  * Websocket callback function for MHD

--- a/test/core.c
+++ b/test/core.c
@@ -167,7 +167,7 @@ static Suite *ulfius_suite(void)
 	Suite *s;
 	TCase *tc_core;
 
-	s = suite_create("Ulfius struct _u_map function tests");
+	s = suite_create("Ulfius core function tests");
 	tc_core = tcase_create("test_ulfius_core");
 	tcase_add_test(tc_core, test_ulfius_init_instance);
 	tcase_add_test(tc_core, test_endpoint);

--- a/test/core.c
+++ b/test/core.c
@@ -91,6 +91,9 @@ START_TEST(test_endpoint)
   ck_assert_int_eq(ulfius_set_default_endpoint(&u_instance, NULL, NULL), U_ERROR_PARAMS);
   ck_assert_int_eq(ulfius_set_default_endpoint(&u_instance, &callback_function_empty, NULL), U_OK);
   
+  o_free(endpoint.http_method);
+  o_free(endpoint.url_prefix);
+  o_free(endpoint.url_format);
   ulfius_clean_instance(&u_instance);
 }
 END_TEST
@@ -159,29 +162,16 @@ fYxFAheH3CjryHqqR9DD+d9396W8mqEaUp+plMwSjpcTDSR4rEQkUJg=\
 }
 END_TEST
 
-START_TEST(test_ulfius_base64)
-{
-  char * src = "source string", encoded[128], decoded[128];
-  size_t encoded_size, decoded_size;
-  ck_assert_int_eq(base64_encode((unsigned char *)src, strlen(src), (unsigned char *)encoded, &encoded_size), 1);
-  ck_assert_str_eq(encoded, "c291cmNlIHN0cmluZw==");
-  ck_assert_int_eq(base64_decode((unsigned char *)encoded, encoded_size, (unsigned char *)decoded, &decoded_size), 1);
-  ck_assert_str_eq(decoded, src);
-  ck_assert_int_eq(decoded_size, strlen(src));
-}
-END_TEST
-
 static Suite *ulfius_suite(void)
 {
 	Suite *s;
 	TCase *tc_core;
 
 	s = suite_create("Ulfius struct _u_map function tests");
-	tc_core = tcase_create("test_ulfius_u_map");
+	tc_core = tcase_create("test_ulfius_core");
 	tcase_add_test(tc_core, test_ulfius_init_instance);
 	tcase_add_test(tc_core, test_endpoint);
 	tcase_add_test(tc_core, test_ulfius_start_instance);
-	tcase_add_test(tc_core, test_ulfius_base64);
 	tcase_set_timeout(tc_core, 30);
 	suite_add_tcase(s, tc_core);
 

--- a/test/framework.c
+++ b/test/framework.c
@@ -150,7 +150,7 @@ void free_stream_data(void * cls) {
 }
 
 int callback_function_stream (const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_stream_response(response, 200, stream_data, free_stream_data, -1, 32 * 1024, o_strdup("stream test"));
+  ulfius_set_stream_response(response, 200, stream_data, free_stream_data, U_STREAM_SIZE_UNKOWN, 32 * 1024, o_strdup("stream test"));
   return U_OK;
 }
 

--- a/test/framework.c
+++ b/test/framework.c
@@ -141,7 +141,7 @@ ssize_t stream_data (void * cls, uint64_t pos, char * buf, size_t max) {
       snprintf(buf, max, "%s %" PRIu64 "\n", (char *)cls, pos + 1);
       return strlen(buf);
   } else {
-    return U_STREAM_END;
+    return MHD_CONTENT_READER_END_OF_STREAM;
   }
 }
 

--- a/test/framework.c
+++ b/test/framework.c
@@ -49,7 +49,7 @@ int callback_function_empty(const struct _u_request * request, struct _u_respons
 }
 
 int callback_function_return_url(const struct _u_request * request, struct _u_response * response, void * user_data) {
-  ulfius_set_string_response(response, 200, request->http_url);
+  ulfius_set_string_body_response(response, 200, request->http_url);
   return U_CALLBACK_CONTINUE;
 }
 
@@ -78,7 +78,7 @@ int callback_function_param(const struct _u_request * request, struct _u_respons
     param3 = o_strdup("");
   }
   body = msprintf("param1 is %s, param2 is %s%s", u_map_get(request->map_url, "param1"), u_map_get(request->map_url, "param2"), param3);
-  ulfius_set_string_response(response, 200, body);
+  ulfius_set_string_body_response(response, 200, body);
   o_free(body);
   o_free(param3);
   return U_CALLBACK_CONTINUE;
@@ -88,7 +88,7 @@ int callback_function_body_param(const struct _u_request * request, struct _u_re
   char * body;
   
   body = msprintf("param1 is %s, param2 is %s", u_map_get(request->map_post_body, "param1"), u_map_get(request->map_post_body, "param2"));
-  ulfius_set_string_response(response, 200, body);
+  ulfius_set_string_body_response(response, 200, body);
   o_free(body);
   return U_CALLBACK_CONTINUE;
 }
@@ -97,7 +97,7 @@ int callback_function_header_param(const struct _u_request * request, struct _u_
   char * body;
   
   body = msprintf("param1 is %s, param2 is %s", u_map_get(request->map_header, "param1"), u_map_get(request->map_header, "param2"));
-  ulfius_set_string_response(response, 200, body);
+  ulfius_set_string_body_response(response, 200, body);
   o_free(body);
   return U_CALLBACK_CONTINUE;
 }
@@ -106,7 +106,7 @@ int callback_function_cookie_param(const struct _u_request * request, struct _u_
   char * body;
   
   body = msprintf("param1 is %s", u_map_get(request->map_cookie, "param1"));
-  ulfius_set_string_response(response, 200, body);
+  ulfius_set_string_body_response(response, 200, body);
   ulfius_add_cookie_to_response(response, "param2", "value_cookie", NULL, 100, "localhost", "/cookie", 0, 1);
   o_free(body);
   return U_CALLBACK_CONTINUE;
@@ -115,10 +115,10 @@ int callback_function_cookie_param(const struct _u_request * request, struct _u_
 int callback_function_multiple_continue(const struct _u_request * request, struct _u_response * response, void * user_data) {
   if (response->binary_body != NULL) {
     char * body = msprintf("%.*s\n%s", response->binary_body_length, (char*)response->binary_body, request->http_url);
-    ulfius_set_string_response(response, 200, body);
+    ulfius_set_string_body_response(response, 200, body);
     o_free(body);
   } else {
-    ulfius_set_string_response(response, 200, request->http_url);
+    ulfius_set_string_body_response(response, 200, request->http_url);
   }
   return U_CALLBACK_CONTINUE;
 }
@@ -126,17 +126,17 @@ int callback_function_multiple_continue(const struct _u_request * request, struc
 int callback_function_multiple_complete(const struct _u_request * request, struct _u_response * response, void * user_data) {
   if (response->binary_body != NULL) {
     char * body = msprintf("%.*s\n%s", response->binary_body_length, (char*)response->binary_body, request->http_url);
-    ulfius_set_string_response(response, 200, body);
+    ulfius_set_string_body_response(response, 200, body);
     o_free(body);
   } else {
-    ulfius_set_string_response(response, 200, request->http_url);
+    ulfius_set_string_body_response(response, 200, request->http_url);
   }
   return U_CALLBACK_COMPLETE;
 }
 
 
 ssize_t stream_data (void * cls, uint64_t pos, char * buf, size_t max) {
-  sleep(1);
+  usleep(100);
   if (pos <= 100) {
       snprintf(buf, max, "%s %" PRIu64 "\n", (char *)cls, pos + 1);
       return strlen(buf);
@@ -521,7 +521,7 @@ static Suite *ulfius_suite(void)
 	TCase *tc_core;
 
 	s = suite_create("Ulfius struct _u_map function tests");
-	tc_core = tcase_create("test_ulfius_u_map");
+	tc_core = tcase_create("test_ulfius_framework");
 	tcase_add_test(tc_core, test_ulfius_simple_endpoint);
 	tcase_add_test(tc_core, test_ulfius_endpoint_parameters);
 	tcase_add_test(tc_core, test_ulfius_endpoint_injection);

--- a/test/framework.c
+++ b/test/framework.c
@@ -520,7 +520,7 @@ static Suite *ulfius_suite(void)
 	Suite *s;
 	TCase *tc_core;
 
-	s = suite_create("Ulfius struct _u_map function tests");
+	s = suite_create("Ulfius framework function tests");
 	tc_core = tcase_create("test_ulfius_framework");
 	tcase_add_test(tc_core, test_ulfius_simple_endpoint);
 	tcase_add_test(tc_core, test_ulfius_endpoint_parameters);


### PR DESCRIPTION
- An annoying bug has been fixed that made streaming data a little buggy when used on raspbian. Now if you don't know the data size you're sending, use the macro U_STREAM_SIZE_UNKOWN instead of the previous value -1. There is some updates in the stream callback function parameter types. Check the streaming data documentation.
- Fix bug on ulfius_send_http_request that didn't send back all headers value with the same name (#19)
- Fix websocket declaration structures to have them outside of the ulfius.h, because it could lead to horrifying bugs when you compile ulfius with websocket but add #define U_DISABLE_WEBSOCKET in your application.
- Add proxy value for outgoing requests (#18)
- Unify and update functions name ulfius_set_[string|json|binary]_body. You may have to update your legacy code.