### PR TITLE
MSVC support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,11 +184,13 @@ endif ()
 # shared library
 
 add_library(ulfius SHARED ${LIB_SRC})
-set_target_properties(ulfius PROPERTIES
-    COMPILE_OPTIONS -Wextra
-    PUBLIC_HEADER "${INC_DIR}/ulfius.h;${PROJECT_BINARY_DIR}/ulfius-cfg.h"
-    VERSION "${LIBRARY_VERSION}"
-    SOVERSION "${LIBRARY_SOVERSION}")
+if (NOT MSVC)
+    set_target_properties(ulfius PROPERTIES
+        COMPILE_OPTIONS -Wextra
+        PUBLIC_HEADER "${INC_DIR}/ulfius.h;${PROJECT_BINARY_DIR}/ulfius-cfg.h"
+        VERSION "${LIBRARY_VERSION}"
+        SOVERSION "${LIBRARY_SOVERSION}")
+endif()
 if (WIN32)
     set_target_properties(ulfius PROPERTIES SUFFIX "-${LIBRARY_VERSION_MAJOR}.dll")
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ cmake_minimum_required(VERSION 3.5)
 project(ulfius C)
 
 set(CMAKE_C_STANDARD 99)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+if (NOT MSVC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror")
+endif()
 
 # library info
 

--- a/src/u_request.c
+++ b/src/u_request.c
@@ -28,6 +28,10 @@
 #include "u_private.h"
 #include "ulfius.h"
 
+#ifdef _MSC_VER
+#define strtok_r strtok_s
+#endif
+
 /**
  * Splits the url to an array of char *
  */

--- a/src/u_send_request.c
+++ b/src/u_send_request.c
@@ -32,6 +32,21 @@
 #include <curl/curl.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+#define strtok_r strtok_s
+
+struct tm* gmtime_r(const time_t* t, struct tm* r) {
+    // gmtime is threadsafe in windows
+    struct tm* that = gmtime(t);
+    if (that) {
+        *r = *that;
+        return r;
+    } else {
+        return 0;
+    }
+}
+#endif
+
 /**
  * Internal structure used to store temporarly the response body
  */


### PR DESCRIPTION
With [#12](https://github.com/babelouest/yder/pull/12) and [#22](https://github.com/babelouest/orcania/pull/22) ulfius is build on MSVC 2017 & [vcpkg](https://github.com/Microsoft/vcpkg) without GNU TLS support.

If these three pull request will be merged i am going to prepare a vcpkg config for the ulfius.