### PR TITLE
Fix non-checked certificate trust (gnutls)

### DIFF
--- a/src/ulfius.c
+++ b/src/ulfius.c
@@ -402,7 +402,7 @@ static int ulfius_webservice_dispatcher (void * cls, struct MHD_Connection * con
 #ifndef U_DISABLE_GNUTLS
     ci = MHD_get_connection_info (connection, MHD_CONNECTION_INFO_GNUTLS_SESSION);
     if (((struct _u_instance *)cls)->use_client_cert_auth && ci != NULL && ci->tls_session != NULL) {
-      if ((ret_cert = gnutls_certificate_verify_peers2(ci->tls_session, &client_cert_status)) != 0 && ret_cert != GNUTLS_E_NO_CERTIFICATE_FOUND) {
+      if (((ret_cert = gnutls_certificate_verify_peers2(ci->tls_session, &client_cert_status)) != 0 && ret_cert != GNUTLS_E_NO_CERTIFICATE_FOUND) || client_cert_status != 0) {
         y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Error gnutls_certificate_verify_peers2");
       } else if (!ret_cert) {
         pcert = gnutls_certificate_get_peers(ci->tls_session, &listsize);

--- a/src/ulfius.c
+++ b/src/ulfius.c
@@ -371,7 +371,7 @@ static int ulfius_webservice_dispatcher (void * cls, struct MHD_Connection * con
   const union MHD_ConnectionInfo * ci;
   unsigned int listsize;
   const gnutls_datum_t * pcert;
-  gnutls_certificate_status_t client_cert_status;
+  gnutls_certificate_status_t client_cert_status = 0;
   int ret_cert;
 #endif
   char * content_type, * auth_realm = NULL;
@@ -412,7 +412,7 @@ static int ulfius_webservice_dispatcher (void * cls, struct MHD_Connection * con
           y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Failed to initialize client certificate");
         } else if (gnutls_x509_crt_import(con_info->request->client_cert, &pcert[0], GNUTLS_X509_FMT_DER)) {
           y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Failed to import client certificate");
-          gnutls_x509_crt_deinit(con_info->request->client_cert);
+          gnutls_x509_crt_deinit(con_info->request->client_cert);git@github.com:yomgui1/ulfius.git
         }
       }
     }


### PR DESCRIPTION
This patch fixes client certificate verification.
Without, a MITM attack is possible as we don't check the gnutls client certificate verification status code.