### PR TITLE
Define MSG_NOSIGNAL if not defined

### DIFF
--- a/src/u_websocket.c
+++ b/src/u_websocket.c
@@ -26,6 +26,10 @@
 #include "u_private.h"
 #include "ulfius.h"
 
+#if defined(__APPLE__) && !defined (MSG_NOSIGNAL)
+  #define MSG_NOSIGNAL 0
+#endif
+
 #ifndef U_DISABLE_WEBSOCKET
 #include "yuarel.h"
 #include <string.h>


### PR DESCRIPTION
`MSG_NOSIGNAL` is not defined on OSX.

This is a quick and dirty fix but allows me to build ulfius on OSX.