### PR TITLE
u_send_request.c: fix bug about missing "res" variable assignment

### DIFF
--- a/src/u_send_request.c
+++ b/src/u_send_request.c
@@ -864,7 +864,8 @@ int ulfius_send_smtp_rich_email(const char * host,
           break;
         }
 
-        if (curl_easy_perform(curl_handle) != CURLE_OK) {
+        res = curl_easy_perform(curl_handle);
+        if (res != CURLE_OK) {
           y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Error sending smtp message, error message %s", curl_easy_strerror(res));
           ret = U_ERROR_LIBCURL;
           break;


### PR DESCRIPTION
The y_log_message was printing "res" variable, but the curl_easy_perform return value was not really assigned to that variable.