### PR TITLE
don't set json_set_alloc_funcs

### DIFF
--- a/src/u_send_request.c
+++ b/src/u_send_request.c
@@ -218,9 +218,6 @@ int ulfius_send_http_streaming_request(const struct _u_request * request,
     // Duplicate the request and work on it
     if ((copy_request = ulfius_duplicate_request(request)) != NULL) {
       o_get_alloc_funcs(&malloc_fn, &realloc_fn, &free_fn);
-#ifndef U_DISABLE_JANSSON
-      json_set_alloc_funcs((json_malloc_t)malloc_fn, (json_free_t)free_fn);
-#endif
       if (curl_global_init_mem(CURL_GLOBAL_DEFAULT, malloc_fn, free_fn, realloc_fn, *o_strdup, *calloc) == CURLE_OK) {
         if ((curl_handle = curl_easy_init()) != NULL) {
           ret = U_OK;


### PR DESCRIPTION
 don't set json_set_alloc_funcs on each send request, set json_set_alloc_funcs on startup is enough.