### PR TITLE
Changes in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
   include:
     - env: LABEL=gcc
       compiler: gcc
-    - env: LABEL=cland
+    - env: LABEL=clang
       compiler: clang
     - env: LABEL=cppcheck
       script:
@@ -21,7 +21,7 @@ jobs:
     - env: LABEL=gcc
       arch: ppc64le
       compiler: gcc
-    - env: LABEL=cland
+    - env: LABEL=clang
       arch: ppc64le
       compiler: clang
     - env: LABEL=cppcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,17 @@ jobs:
     - env: LABEL=cppcheck
       script:
         - cppcheck --force --enable=warning,missingInclude --error-exitcode=1 . >build.log 2>&1 || (cat build.log && exit 1)
+# ppc64le support code
+    - env: LABEL=gcc
+      arch: ppc64le
+      compiler: gcc
+    - env: LABEL=cland
+      arch: ppc64le
+      compiler: clang
+    - env: LABEL=cppcheck
+      arch: ppc64le
+      script:
+        - cppcheck --force --enable=warning,missingInclude --error-exitcode=1 . >build.log 2>&1 || (cat build.log && exit 1)
 
 install:
 - sudo sysctl -w net.ipv6.conf.all.disable_ipv6=0


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.org/github/nageshlop/ulfius