### PR TITLE
docs: fix simple typo, temporarly -> temporarily

### DIFF
--- a/src/u_send_request.c
+++ b/src/u_send_request.c
@@ -59,7 +59,7 @@ struct tm * gmtime_r(const time_t* t, struct tm* r) {
 #endif
 
 /**
- * Internal structure used to store temporarly the response body
+ * Internal structure used to store temporarily the response body
  */
 struct _u_body {
   char * data;


### PR DESCRIPTION
There is a small typo in src/u_send_request.c.

Should read `temporarily` rather than `temporarly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md