### PR TITLE
Fix certificate generation on MacOS

### DIFF
--- a/test/cert/create-cert.sh
+++ b/test/cert/create-cert.sh
@@ -3,6 +3,14 @@
 DEST=./cert
 RET=0
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # Apple has its own certtool which is incompatible. GnuTLS' certtool is renamed as
+  # gnutls-certtool in MacPorts/homebrew.
+  CERTTOOL=gnutls-certtool
+else
+  CERTTOOL=certtool
+fi
+
 # clean old certs
 rm -f $DEST/server.* $DEST/root* $DEST/client*
 
@@ -11,7 +19,7 @@ echo Generate Ulfius test certificates >> $DEST/certtool.log
 echo >> $DEST/certtool.log
 
 # www cert
-certtool --generate-privkey --outfile $DEST/server.key --sec-param High 2>>$DEST/certtool.log
+$CERTTOOL --generate-privkey --outfile $DEST/server.key --sec-param High 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "server.key         \033[0;32mOK\033[0m\n"
@@ -19,7 +27,7 @@ else
   printf "server.key         \033[0;31mError\033[0m\n"
   RET=$STATUS
 fi
-certtool --generate-self-signed --load-privkey $DEST/server.key --outfile $DEST/server.crt --template $DEST/template-server.cfg 2>>$DEST/certtool.log
+$CERTTOOL --generate-self-signed --load-privkey $DEST/server.key --outfile $DEST/server.crt --template $DEST/template-server.cfg 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "server.crt         \033[0;32mOK\033[0m\n"
@@ -29,7 +37,7 @@ else
 fi
 
 # CA root
-certtool --generate-privkey --outfile $DEST/root1.key --sec-param High 2>>$DEST/certtool.log
+$CERTTOOL --generate-privkey --outfile $DEST/root1.key --sec-param High 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "root1.key          \033[0;32mOK\033[0m\n"
@@ -37,7 +45,7 @@ else
   printf "root1.key          \033[0;31mError\033[0m\n"
   RET=$STATUS
 fi
-certtool --generate-self-signed --load-privkey $DEST/root1.key --outfile $DEST/root1.crt --template $DEST/template-ca.cfg 2>>$DEST/certtool.log
+$CERTTOOL --generate-self-signed --load-privkey $DEST/root1.key --outfile $DEST/root1.crt --template $DEST/template-ca.cfg 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "root1.crt          \033[0;32mOK\033[0m\n"
@@ -47,7 +55,7 @@ else
 fi
 
 # client 1
-certtool --generate-privkey --outfile $DEST/client1.key --sec-param High 2>>$DEST/certtool.log
+$CERTTOOL --generate-privkey --outfile $DEST/client1.key --sec-param High 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "client1.key        \033[0;32mOK\033[0m\n"
@@ -55,7 +63,7 @@ else
   printf "client1.key        \033[0;31mError\033[0m\n"
   RET=$STATUS
 fi
-certtool --generate-certificate --load-privkey $DEST/client1.key --load-ca-certificate $DEST/root1.crt --load-ca-privkey $DEST/root1.key --outfile $DEST/client1.crt --template $DEST/template-client.cfg 2>>$DEST/certtool.log
+$CERTTOOL --generate-certificate --load-privkey $DEST/client1.key --load-ca-certificate $DEST/root1.crt --load-ca-privkey $DEST/root1.key --outfile $DEST/client1.crt --template $DEST/template-client.cfg 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "client1.crt        \033[0;32mOK\033[0m\n"
@@ -65,7 +73,7 @@ else
 fi
 
 # CA root 2
-certtool --generate-privkey --outfile $DEST/root2.key --sec-param High 2>>$DEST/certtool.log
+$CERTTOOL --generate-privkey --outfile $DEST/root2.key --sec-param High 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "root2.key          \033[0;32mOK\033[0m\n"
@@ -73,7 +81,7 @@ else
   printf "root2.key          \033[0;31mError\033[0m\n"
   RET=$STATUS
 fi
-certtool --generate-self-signed --load-privkey $DEST/root2.key --outfile $DEST/root2.crt --template $DEST/template-ca2.cfg 2>>$DEST/certtool.log
+$CERTTOOL --generate-self-signed --load-privkey $DEST/root2.key --outfile $DEST/root2.crt --template $DEST/template-ca2.cfg 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "root2.crt          \033[0;32mOK\033[0m\n"
@@ -83,7 +91,7 @@ else
 fi
 
 # client 2
-certtool --generate-privkey --outfile $DEST/client2.key --sec-param High 2>>$DEST/certtool.log
+$CERTTOOL --generate-privkey --outfile $DEST/client2.key --sec-param High 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "client2.key        \033[0;32mOK\033[0m\n"
@@ -91,7 +99,7 @@ else
   printf "client2.key        \033[0;31mError\033[0m\n"
   RET=$STATUS
 fi
-certtool --generate-certificate --load-privkey $DEST/client2.key --load-ca-certificate $DEST/root2.crt --load-ca-privkey $DEST/root2.key --outfile $DEST/client2.crt --template $DEST/template-client.cfg 2>>$DEST/certtool.log
+$CERTTOOL --generate-certificate --load-privkey $DEST/client2.key --load-ca-certificate $DEST/root2.crt --load-ca-privkey $DEST/root2.key --outfile $DEST/client2.crt --template $DEST/template-client.cfg 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "client2.crt        \033[0;32mOK\033[0m\n"
@@ -101,7 +109,7 @@ else
 fi
 
 # client 3 self-signed
-certtool --generate-privkey --outfile $DEST/client3.key --sec-param High 2>>$DEST/certtool.log
+$CERTTOOL --generate-privkey --outfile $DEST/client3.key --sec-param High 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "client3.key        \033[0;32mOK\033[0m\n"
@@ -109,7 +117,7 @@ else
   printf "client3.key        \033[0;31mError\033[0m\n"
   RET=$STATUS
 fi
-certtool --generate-self-signed --load-privkey $DEST/client3.key --outfile $DEST/client3.crt --template $DEST/template-client.cfg 2>>$DEST/certtool.log
+$CERTTOOL --generate-self-signed --load-privkey $DEST/client3.key --outfile $DEST/client3.crt --template $DEST/template-client.cfg 2>>$DEST/certtool.log
 STATUS=$?
 if [ $STATUS -eq 0 ]; then
   printf "client3.crt        \033[0;32mOK\033[0m\n"


### PR DESCRIPTION
I discovered that the script which is used to generate certificates `test/cert/create-cert.sh` fails on MacOS because it it using `certtool`. Apple provides it's own version of `certtool` which accepts a different set of parameters, and is incompatible with the Linux version. GnuTLS' certtool is distributed as `gnutls-certtool` in MacPorts/homebrew, so let's make the script use the proper tool based on the OS type.