### PR TITLE
u_request: Don't use malloc, but always o_malloc

### DIFF
--- a/src/u_request.c
+++ b/src/u_request.c
@@ -143,7 +143,7 @@ static char from_hex(char ch) {
  */
 static char * url_decode(const char * str) {
   if (str != NULL) {
-    char * pstr = (char*)str, * buf = malloc(strlen(str) + 1), * pbuf = buf;
+    char * pstr = (char*)str, * buf = o_malloc(strlen(str) + 1), * pbuf = buf;
     while (* pstr) {
       if (* pstr == '%') {
         if (pstr[1] && pstr[2]) {

--- a/src/ulfius.c
+++ b/src/ulfius.c
@@ -1842,7 +1842,7 @@ static char to_hex(char code) {
 char * ulfius_url_encode(const char * str) {
   char * pstr = (char*)str, * buf = NULL, * pbuf = NULL;
   if (str != NULL) {
-    buf = malloc(strlen(str) * 3 + 1);
+    buf = o_malloc(strlen(str) * 3 + 1);
     if (buf != NULL) {
       pbuf = buf;
       while (* pstr) {
@@ -1876,7 +1876,7 @@ char * ulfius_url_encode(const char * str) {
 char * ulfius_url_decode(const char * str) {
   char * pstr = (char*)str, * buf = NULL, * pbuf = NULL;
   if (str != NULL) {
-    buf = malloc(strlen(str) + 1);
+    buf = o_malloc(strlen(str) + 1);
     if (buf != NULL) {
       pbuf = buf;
       while (* pstr) {


### PR DESCRIPTION
Allocating memory using malloc, but then free'ing it using o_free will
not work for anyone using a custom memory allocator.   The allocations
and free's must either both go to libc, or both via the custom
allocator; one cannot allocate one way and release another.

Closes: #206