### PR TITLE
Websockets: fix case where server sends a 0-length packet

### DIFF
--- a/src/u_websocket.c
+++ b/src/u_websocket.c
@@ -815,14 +815,14 @@ static int ulfius_get_next_line_from_http_response(struct _websocket * websocket
     if (read_data_from_socket(websocket->websocket_manager, &car, 1) == 1) {
       buffer[offset] = (char)car;
 
-    if (offset > 0 && buffer[offset-1] == '\r' && buffer[offset] == '\n') {
-      eol = 1;
-      buffer[offset-1] = '\0';
-      *line_len = offset - 1;
-      ret = U_OK;
-    }
+      if (offset > 0 && buffer[offset-1] == '\r' && buffer[offset] == '\n') {
+        eol = 1;
+        buffer[offset-1] = '\0';
+        *line_len = offset - 1;
+        ret = U_OK;
+      }
 
-    offset++;
+      offset++;
     }
   } while (websocket->websocket_manager->connected && !eol && offset < buffer_len);
 

--- a/src/u_websocket.c
+++ b/src/u_websocket.c
@@ -814,7 +814,6 @@ static int ulfius_get_next_line_from_http_response(struct _websocket * websocket
   do {
     if (read_data_from_socket(websocket->websocket_manager, &car, 1) == 1) {
       buffer[offset] = (char)car;
-    }
 
     if (offset > 0 && buffer[offset-1] == '\r' && buffer[offset] == '\n') {
       eol = 1;
@@ -824,6 +823,7 @@ static int ulfius_get_next_line_from_http_response(struct _websocket * websocket
     }
 
     offset++;
+    }
   } while (websocket->websocket_manager->connected && !eol && offset < buffer_len);
 
   if (!websocket->websocket_manager->connected && !eol && offset < buffer_len) {


### PR DESCRIPTION
When handling a zero-length packet, the websocket client incorrectly increments the buffer offset pointer without writing any data. Fix this by moving a curly brace, so that the buffer offset pointer is not changed in that case.