### PR TITLE
Fix the `uwsc --quiet` long option to properly enable quiet mode

### DIFF
--- a/tools/uwsc/uwsc.c
+++ b/tools/uwsc/uwsc.c
@@ -284,7 +284,7 @@ int main (int argc, char ** argv) {
     {"protocol", required_argument, NULL, 'p'},         // Websocket protocol
     {"extensions", required_argument, NULL, 'e'},       // Websocket extensions
     {"non-secure", no_argument, NULL, 's'},             // Do not check server certificate
-    {"quiet", no_argument, NULL, 'v'},                  // Quiet mode
+    {"quiet", no_argument, NULL, 'q'},                  // Quiet mode
     {"version", no_argument, NULL, 'v'},                // Show version
     {"help", no_argument, NULL, 'h'},                   // print help
     {NULL, 0, NULL, 0}


### PR DESCRIPTION
Previously it enabled version printing mode instead,
because it was associated with the 'v' short option.

Fixes: commit f7efb9e0833c79b55c4c8370f65aa98225c4afec
