### PR TITLE
Add network_interface option to bind outgoing HTTP requests to a spec…

### DIFF
--- a/include/ulfius.h
+++ b/include/ulfius.h
@@ -245,6 +245,7 @@ struct _u_request {
   int                  check_proxy_certificate_flag; /* !< check certificate peer and or proxy hostname if check_proxy_certificate is enabled, values available are U_SSL_VERIFY_PEER, U_SSL_VERIFY_HOSTNAME or both, default value is both (U_SSL_VERIFY_PEER|U_SSL_VERIFY_HOSTNAME), used by ulfius_send_http_request, requires libcurl >= 7.52 */
   int                  follow_redirect; /* !< follow url redirections, used by ulfius_send_http_request */
   char *               ca_path; /* !< specify a path to CA certificates instead of system path, used by ulfius_send_http_request */
+  char *               network_interface; /* !< bind outgoing socket to this interface/IP (CURLOPT_INTERFACE), used by ulfius_send_http_request */
   unsigned long        timeout; /* !< connection timeout used by ulfius_send_http_request, default is 0 */
   struct sockaddr *    client_address; /* !< IP address of the client */
   char *               auth_basic_user; /* !< basic authentication username */

--- a/src/u_request.c
+++ b/src/u_request.c
@@ -287,6 +287,7 @@ int ulfius_init_request(struct _u_request * request) {
     request->http_url = NULL;
     request->url_path = NULL;
     request->proxy = NULL;
+    request->network_interface = NULL;
 #if MHD_VERSION >= 0x00095208
     request->network_type = U_USE_ALL;
 #endif
@@ -327,6 +328,7 @@ int ulfius_clean_request(struct _u_request * request) {
     o_free(request->http_url);
     o_free(request->url_path);
     o_free(request->proxy);
+    o_free(request->network_interface);
     o_free(request->auth_basic_user);
     o_free(request->auth_basic_password);
     o_free(request->client_address);
@@ -340,6 +342,7 @@ int ulfius_clean_request(struct _u_request * request) {
     request->http_verb = NULL;
     request->http_url = NULL;
     request->proxy = NULL;
+    request->network_interface = NULL;
     request->client_address = NULL;
     request->map_url = NULL;
     request->map_header = NULL;
@@ -385,6 +388,7 @@ int ulfius_copy_request(struct _u_request * dest, const struct _u_request * sour
     dest->http_url = o_strdup(source->http_url);
     dest->url_path = o_strdup(source->url_path);
     dest->proxy = o_strdup(source->proxy);
+    dest->network_interface = o_strdup(source->network_interface);
 #if MHD_VERSION >= 0x00095208
     dest->network_type = source->network_type;
 #endif

--- a/src/u_send_request.c
+++ b/src/u_send_request.c
@@ -384,6 +384,15 @@ int ulfius_send_http_streaming_request_max_header(const struct _u_request * requ
             }
           }
 
+          // Bind outgoing socket to a specific network interface if set
+          if (copy_request->network_interface != NULL) {
+            if (curl_easy_setopt(curl_handle, CURLOPT_INTERFACE, copy_request->network_interface) != CURLE_OK) {
+              y_log_message(Y_LOG_LEVEL_ERROR, "Ulfius - Error setting network_interface option");
+              ret = U_ERROR_LIBCURL;
+              break;
+            }
+          }
+
           // follow redirection if set
           if (copy_request->follow_redirect) {
             if (curl_easy_setopt(curl_handle, CURLOPT_FOLLOWLOCATION, 1) != CURLE_OK) {


### PR DESCRIPTION
  Summary
                                                                                                                                              
  - Adds char * network_interface field to struct _u_request in ulfius.h, allowing callers to bind outgoing HTTP requests to a specific network interface or IP address (via libcurl's CURLOPT_INTERFACE)
  - Initializes the field to NULL in ulfius_init_request, frees and nulls it in ulfius_clean_request, and deep-copies it in                  ulfius_copy_request                                                                                                                         
  - In ulfius_send_http_request, sets CURLOPT_INTERFACE on the curl handle when network_interface is non-NULL, with appropriate error logging on failure 