### PR TITLE
Fix under-allocation in ulfius_websocket_pop_first_message realloc

### DIFF
--- a/src/u_websocket.c
+++ b/src/u_websocket.c
@@ -1646,7 +1646,7 @@ struct _websocket_message * ulfius_websocket_pop_first_message(struct _websocket
       message_list->list[len] = message_list->list[len+1];
     }
     if (message_list->len > 1) {
-      message_list->list = o_realloc(message_list->list, (message_list->len-1));
+      message_list->list = o_realloc(message_list->list, (message_list->len-1)*sizeof(struct _websocket_message *));
     } else {
       o_free(message_list->list);
       message_list->list = NULL;


### PR DESCRIPTION
## Bug

In `src/u_websocket.c`, `ulfius_websocket_pop_first_message()` shrinks
`message_list->list` (a `struct _websocket_message **`, i.e. an array
of pointers) with:

```c
message_list->list = o_realloc(message_list->list, (message_list->len-1));
```

The size argument is a raw count of `(len-1)` **bytes**, not
`(len-1)` **pointers**. The correct pattern is already used a few
lines above in `ulfius_push_websocket_message()`:

```c
message_list->list = o_realloc(message_list->list, (message_list->len+1)*sizeof(struct _websocket_message *));
```

On a 64-bit build this under-allocates the shrunk array by a factor
of 8 (`sizeof(struct _websocket_message *)` == 8). Every element
write to `message_list->list[]` past the first pointer writes past
the end of the (undersized) heap allocation.

## Impact

`ulfius_websocket_pop_first_message()` is a public API function, and
message-list retention defaults to
`U_WEBSOCKET_KEEP_INCOMING|U_WEBSOCKET_KEEP_OUTCOMING` (see API.md),
so this is hit through the documented drain pattern (repeatedly
popping messages off a websocket's message list), not just an edge
case. Repeated pops corrupt the heap and can crash the process.

## Fix

One-line fix: include the missing `* sizeof(struct
_websocket_message *)` in the realloc size argument, mirroring the
already-correct line in `ulfius_push_websocket_message()`.

## Testing

Verified locally with a standalone harness that reproduces the exact
struct layout and function bodies (both the buggy and fixed
versions) linked against real `malloc`/`realloc`/`free` semantics
matching orcania's `o_malloc`/`o_realloc`/`o_free`:

- Buggy version: after push 5 + 1 pop, the array's actual usable
  allocation drops to 1/8th of what's required; continuing the
  documented push/pop-all drain pattern reliably crashes with heap
  corruption after a handful of pops.
- Fixed version (this PR): the same push/pop-all drain pattern
  completes cleanly with no corruption.